### PR TITLE
Refactor/io

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ import tkyoDrift from tkyoDrift
 3. Add an async function call to the tkyoDrift main function passing in your I/O pair:
 ```js
 ...
-async tkyoDrift(userinput, aioutput)
+tkyoDrift(userinput, aioutput)
 ... 
 ```
 4. Enjoy the benefits of having drift detection:
@@ -111,7 +111,7 @@ IMPORTANT! The set training data file should ONLY be run when you intend on repl
 
 <<< There should only be ONE set of ideal embeddings for your training data. >>>
 ``` 
-As an additional note, you will see a console log warning that inputs exceeding 512 tokens will result in indexing errors. This is accounted for in the embedding process, and all inputs over 512 tokens will return the average vector of each 512 token chunk.
+As an additional note, the batch embedding tool is designed to indiscriminantly ingest all `.arrow` files in the directory you specify. If needed, nest your training data in a subdirectory to avoid ingesting data other than your intended files. Also, please ensure your data is structured uniformly.
 
 ## Logging
 

--- a/README.md
+++ b/README.md
@@ -2,38 +2,76 @@
   <img src="tkyo-banner.png" width="100%" alt="TKYO Drift Banner">
 </p>
 
-# AI Temporal Knowledge Yield Output Drift Tracker (TKYO Drift) 
+# AI Temporal Knowledge Yield Output Drift Tracker (TKYO Drift)
 
 ![npm](https://img.shields.io/npm/v/tkyoDrift?style=flat-square)
 ![license](https://img.shields.io/github/license/oslabs-beta/tkyo-drift?style=flat-square)
 ![issues](https://img.shields.io/github/issues/oslabs-beta/tkyo-drift?style=flat-square)
 ![last commit](https://img.shields.io/github/last-commit/oslabs-beta/tkyo-drift?style=flat-square)
 
-TKYO Drift is a lightweight, transparent drift tracking library for AI workflows. It embeds I/O Pairs and compares them to a configurable baseline to detect drift in semantic, conceptual, or lexical meaning over time.
+TKYO Drift is a lightweight, transparent AI drift tracking library for AI workflows of any complexity. It embeds text inputs and compares them to a configurable baseline to detect both drift in an individual input's semantic, conceptual, or lexical meaning over time, as well as population distribution stability across a range of scalar metrics.
 
-**At the time of writing, this tool is only able to ingest data from mono modal text generation AI workflows.**  
+**At the time of writing, this tool is only able to ingest data from mono modal text AI workflows.**
 
 ## Overview
 
-This tool is designed for performance-critical environments and was designed to be operable in production environments. The tkyoDrift() function can be inserted into a text generation workflow as an asynchronous function to minimize performance impacts in production settings. It operates quasi-locally with Python dependencies using the a JS transformers library to support both real-time logging of new I/O data, and batch ingestion of I/O training data. Drift is tracked via cosine similarity against baselines, and stored in compact binary files.
+TKYO Drift is a lightweight drift tracking framework for modern AI workflows. It monitors the _meaning_, _structure_, and _consistency_ of text-based interactions over time to help you catch when an AI model, a user, or both start to change their behavior.
+
+**Why does this matter?**
+
+In production, even minor changes to prompts, model weights, or input phrasing can cause subtle shifts in how your model responds, what it says, how long it is, whether it maintains tone, intent, or factual alignment. These shifts are often invisible unless you're actively tracking them.
+
+And it’s not just the model: user language evolves too. New slang, trending phrases, or tone shifts may emerge that your model wasn't trained on and without observability, you'll miss them.
+
+TKYO Drift embeds each message and compares it against a configurable baseline using **cosine similarity**, **Euclidean distance**, and scalar features like **punctuation density**, **entropy**, and more. The result is a continuous record of how your model’s and users’ behavior changes over time.
+
+Use it to answer questions like:
+
+- "Has the assistant started responding more verbosely?"
+- "Are our summaries becoming more extractive?"
+- "Did a model update change how we paraphrase?"
+- "Are the kids using newfangled words that don’t make any sense?"
+
+Just keep in mind that this tool doesn't tell you why you are drifting, only that you are, by how much, where, when, and in what direction.
 
 ## Table of Contents
-- [Overview](#overview)
+
 - [Drift Analysis Flow](#drift-analysis-flow)
-- [Installation](#how-do-you-install-this-thing)
-- [Usage](#how-do-you-use-this-thing)
+- [How do you install this thing?](#how-do-you-install-this-thing)
+- [How do you use this thing?](#how-do-you-use-this-thing)
 - [One-off Ingestion](#one-off-ingestion)
+  - [Production Impact](#production-impact)
 - [Training Ingestion](#training-ingestion)
 - [Logging](#logging)
+  - [Format](#format)
 - [CLI Tools](#cli-tools)
-- [Architecture](#architecture)
+  - [printLogCLI.js](#printlogclijs)
+  - [printScalarCLI.js](#printscalarclijs)
+- [Architecture Decisions](#architecture)
+  - [Embedding Models](#embedding-models)
+  - [Xenova/Hugging Face Transformer Library](#xenovahugging-face-transformer-library)
+  - [Drift Types](#drift-types)
+  - [Baseline Types](#baseline-types)
+  - [Binary Embedding Storage](#binary-embedding-storage)
+  - [IO Write/Read Methods](#io-writeread-methods)
+- [HNSW Indexing](#hnsw-indexing)
 - [The Math](#the-math)
+  - [Cosine Similarity & Euclidean Distance](#cosine-similarity--euclidean-distance)
+  - [What B Represents](#what-b-represents)
+  - [Centroid Calculation](#centroid-calculation)
 - [Scalar Metrics](#scalar-metrics)
+  - [How Are They Calculated?](#how-are-they-calculated)
+  - [What Do They Tell Us?](#what-do-they-tell-us)
+  - [Comparison Logic](#comparison-logic)
+  - [PSI Values (Population Stability Index)](#psi-values-population-stability-index)
 - [Future Iterations](#future-iterations)
+- [Contributing](#contributing)
+- [License](#license)
+- [Acknowledgments](#acknowledgments)
 
 ## Drift Analysis Flow
 
-For each individual input and output, the following workflow is executed in roughly 800ms. 
+For each individual input and output, the following workflow is executed in either roughly 1000ms, or 500ms in a warm environment (see production impact for more).
 
 1. Generate embeddings for both input and output.
 2. Save them to `.bin` files (except for training mode).
@@ -42,100 +80,249 @@ For each individual input and output, the following workflow is executed in roug
 5. Calculate cosine similarity.
 6. Calculate euclidean distance.
 7. Capture scalar metrics.
-6. Append results to `COS_log.csv`, `EUC_log.csv`, and scalar metric files.
+8. Append results to `COS_log.csv`, `EUC_log.csv`, and scalar metric files.
 
 ```
 Note that the size of input/output text, embedding dimensions, and how many embedding models are chosen will influence the speed of the workflow. Regardless, if tkyoDrift() is called asynchronously, it should not impact your workflow unless you expect a sustained high volume of user inputs per second.
 ```
+
 # How do you install this thing?
+
 TODO: Update this when the NPM package is built.
 
+TODO: They need to install python and it's dependencies, yea?
+
 1. Install the NPM package:
+
 ```bash
 npm install tkyoDrift
 ```
+
 2. Import tkyoDrift into your AI workflow pages:
+
 ```js
 import tkyoDrift from tkyoDrift
 ```
-3. Add an async function call to the tkyoDrift main function passing in your I/O pair:
+
+3. Add a function call to `tkyoDrift(text, inputType)` passing in your text and input type name:
+
 ```js
 ...
-async tkyoDrift(userinput, aioutput)
-... 
+tkyoDrift(userSubmission, 'input')
+...
 ```
+
 4. Enjoy the benefits of having drift detection:
+
 ```
-🏎️☁️☁️☁️ <- THIS GUY IS DRIFTING
+🏎️☁️☁️☁️ <- THAT GUY IS DRIFTING
 ```
 
 # How do you use this thing?
 
-You can interact with this library in 4 ways; 
-- Dispatch a one-off I/O pair to `tkyoDrift()`
-- Dispatch sequential training data through a batch upload to `tkyoDriftSetTraining()`*
-- Request a CLI print out of the log's summary using `npx tkyoDrift -#` (where # is a number of days) 
+TODO: Update this after NPM is built
+You can interact with this library in a couple ways;
+
+- Dispatch a one-off text input and input type to `tkyoDrift()`
+- Dispatch training data through a batch upload to `tkyoDriftSetTraining()`\*
+- Request a CLI print out of the Cosine Similarity log's summary using `npx tkyoDrift -#` (where # is a number of days)
+- Request a CLI print out of the scalar metric's log using `npx tkyoDrift`
 - Export the logs into your Data Viz platform
 
 ```
-* Do this from a strong PC, and then copy your data into the appropriate folders. Due to a number of factors (I/O Length, CUDA access, memory, cpu cores, training data size) this process can take an exceptionally long time to complete.
+* Do this from a strong PC, and then copy your data into the appropriate folders. Due to a number of factors (amount of data, length of individual records, lack of CUDA access, lack of memory, lack of cpu cores, count of embedding models) this process can take an exceptionally long time to complete.
 ```
 
 There is also a small training file downloader script in the util folder called downloadTrainingData.py that you can run to grab the training data from hugging face if you happen to be using a model for your workflow from there.
 
 ## One-off Ingestion
 
-`tkyoDrift.js(input, output, depth)` handles individual I/O pairs for drift comparison. It:
+`tkyoDrift.js(text, type)` handles individual I/O pairs for drift comparison. It:
 
-- Accepts two text strings as `input` and `output` parameters.
-- Accepts an optional 3rd command for the depth* of the I/O pair to enable tracking of nested chain of thought I/O pairs.
-- Embeds serially using as many models as you specify.
+- Accepts two text strings as `input` and `ioType` parameters.
+- Embeds serially using as many models as you specify (default 3).
 - Appends to the rolling data file (only).
 - Reads from the file to load a baseline for comparison.
+- Computes the scalar metrics for the input.
 - Computes the drift score using cosine similarity.
-- Assign a unique ID hash to the I/O pair
+- Adds it to the logs.
 
-```
-* Depth tracking is useful when you have multiple chain of thought workflows, and want to track drift per depth level. Just pass a depth argument for how nested each I/O is. For example, your model might have Human -> AI -> AI, where the first input and last output would be depth = 0, and the middleware AI's input and output would be depth = 1.
-```
+### Production Impact
+
+TKYODrift is designed to run asynchronously in a backend environment, making it ideal for integration as a **non-blocking observer** in production AI workflows.
+
+When the one-off embedding mode is called as above, the system runs as a 'fire-and-forget' process that will record scalar and vector drift without delaying the user response. **The latency impact is limited to system throughput, not response time**.
+
+To minimize load overhead, TKYO Drift includes an internal `MODEL_CACHE` that persists transformer models (e.g., semantic/conceptual/lexical encoders) in memory between requests. When used in a **warm backend process**, this prevents the need to reload model weights on each call — saving up to **52%** of total runtime, as seen in the performance breakdown below.
+
+Drift tracking can be injected at any point in the pipeline where raw text data is available:
+
+- User input → `tkyoDrift(text, "input")`
+- Auto CoT response → `tkyoDrift(text, "cotIntercept1")`
+- System prompt → `tkyoDrift(text, "system")`
+- Another CoT response → `tkyoDrift(text, "cotIntercept2")`
+- Assistant response → `tkyoDrift(text, "output")`
+
+The result is a production-safe drift observability layer that provides transparency across evolving I/O behavior with minimal runtime impact and full logging.
+
+| Stage in order of impact          | Avg Time (ms) | % of Total Time | Spread (ms) |
+| --------------------------------- | ------------- | --------------- | ----------- |
+| Load the Xenova Models            | 563           | 52.5%           | 125         |
+| Read Bin Files                    | 256           | 23.9%           | 51          |
+| Get Embeddings                    | 250           | 23.3%           | 232         |
+| Save Embedding Data               | 1.42          | 0.13%           | 2           |
+| Get Shared Scalar Metrics         | 0.81          | 0.08%           | 1           |
+| Make & Append Log Entries         | 0.35          | 0.03%           | 0           |
+| Save Scalar Data                  | 0.32          | 0.03%           | 0           |
+| Get Cosine Similarity             | 0.28          | 0.03%           | 0           |
+| Get Euclidean Distance            | 0.17          | 0.02%           | 0           |
+| Get Model Specific Scalar Metrics | 0.10          | 0.01%           | 0           |
+| Get Baseline                      | 0.09          | 0.01%           | 0           |
+| Initialize Model File Pathing     | 0.06          | 0.01%           | 0           |
+| Construct Model Combinations      | 0.02          | 0.00%           | 0           |
+
+This table represents a sample runtime breakdown of the one-off embedding flow, measured using the default models in a local Node.js environment with this hardware:
+
+![Sample system specs: Intel Core i9 1300KF with 32 gbs of ram.](hardware.png)
+
+Your actual performance will vary depending on:
+
+- Hardware (CPU vs GPU, disk speed)
+- Token length and input size
+- Number and type of models used
+- Warm vs cold model state
+
+Depending on whether or not your workflow keeps the cache alive this system should be capable of ingesting **1–2 drift events per second per process** without bottleneck.
+
+Higher throughput is achievable by **batching**, **spawning workers**, or **sampling selectively**.
+
+Since the process is fully async and non-blocking, TKYO Drift can be safely parallelized across multiple server threads or microservice instances, allowing it to scale horizontally with user traffic if you need it to.
+
+For higher-frequency use cases (e.g., token-level drift or live CoT chains), we recommend:
+
+- Deploying TKYO Drift in a **separate worker queue**
+- Or integrating it as part of **scheduled post-analysis**, not in-line evaluation
 
 ## Training Ingestion
 
-`tkyoDriftSetTraining.js(filepath)` handles full dataset ingestion for baseline creation. It:
+`tkyoDriftSetTraining.js(filepath, columnName, ioType)` handles full dataset ingestion for baseline creation. It:
 
-- Accepts an array of `{ input, output }` objects.
-- Embeds each input in chunks of 100, with 8 in parallel for performance, once for each model type.
+- Accepts a filepath that contains `columnName` and how you want to reference it as `ioType`.
+- Captures text level, model independent scalar metrics.
+- Embeds each input in chunks of 10, with 8 in parallel for performance, once for each model type.
+- If needed, calculates the average values for embeddings that are longer than 512 tokens by embedding 512 token chunks and then averaging across the set.
 
 ```
-IMPORTANT! The set training data file should ONLY be run when you intend on replacing the existing tkyoDrift training data file set. This command will obliterate any existing tkyoDrift training files. 
+IMPORTANT! The set training data file should ONLY be run when you intend on replacing the existing tkyoDrift training data file set. This function will obliterate any existing tkyoDrift training files, by design.
 
-<<< There should only be ONE set of ideal embeddings for your training data. >>>
-``` 
-As an additional note, you will see a console log warning that inputs exceeding 512 tokens will result in indexing errors. This is accounted for in the embedding process, and all inputs over 512 tokens will return the average vector of each 512 token chunk.
+There should only be ONE set of ideal embeddings for your training data, per ioType.
+```
+As an additional note, the batch embedding tool is designed to indiscriminantly ingest all `.arrow` files in the directory you specify. If needed, nest your training data in a subdirectory to avoid ingesting data other than your intended files.
+
+### Example Input Structure:
+
+Should you have access to training data, you must choose a ioType to associate it with. Preferably, you choose tags for your training data that also exists in your expected one-off function calls to `tkyoDrift(text, ioType)`. For example, a training dataset that contains  problem/solution should have the problem paired with new user inputs (by giving them the same tag), while the solution should be paired with new ai outputs (by giving these the same tag).
+
+In general, the idea is that **a training baseline is only comparable against data that shares  the same ioType**, which is how the system knows what rolling data corresponds to what training data.
+
+When passing the file path,  column header, and tag name into the `tkyoDriftSetTrainingHook.js` function, your object can be structured in the following way:
+
+The system supports **multiple common data formats**:
+
+---
+
+#### Format 1: Flat Columns
+
+If your dataset is structured like this:
+
+```json
+{
+  "input": ["Hello", "How are you?"],
+  "output": ["Hi!", "I'm fine."]
+}
+```
+
+You can call:
+
+```js
+tkyoDriftSetTraining(dataPath, 'input', ioType);
+tkyoDriftSetTraining(dataPath, 'output', ioType);
+```
+Where ioType is some semantic name you choose for each data type.
+
+---
+
+#### Format 2: Nested Fields (OpenAI-style)
+
+If your data has nested fields, such as:
+
+```json
+{
+  "conversations": [
+    { "role": "user", "value": "Hello" },
+    { "role": "assistant", "value": "Hi there!" }
+    { "role": "system", "value": "You're a bot, harry!" }
+  ]
+}
+```
+
+You can use bracket notation to specify the path:
+
+```js
+tkyoDriftSetTraining(dataPath, "['conversations'][0]['value']", ioType);
+tkyoDriftSetTraining(dataPath, "['conversations'][1]['value']", ioType);
+tkyoDriftSetTraining(dataPath, "['conversations'][2]['value']", ioType);
+```
+
+Where ioType is some semantic name you choose for each data type. This lets you embed specific messages or roles within a conversation.
+
+---
+
+#### Format 3: Dictionary of Lists (Batch-style)
+
+Some HuggingFace Datasets may return data like this during `map()` operations:
+
+```json
+{
+  "input": ["Prompt 1", "Prompt 2", "Prompt 3"...],
+  "output": ["Response 1", "Response 2", "Response 3"...]
+}
+```
+
+This is also supported — each row will be reconstructed before accessing your field. Just call the function like so:
+
+```js
+tkyoDriftSetTraining(dataPath, 'input', ioType);
+tkyoDriftSetTraining(dataPath, 'output', ioType);
+```
+Again, where ioType is a semantic name you choose for the data type.
 
 ## Logging
 
-Results are stored in two CSV files (`COS_log.csv` & `EUC_log.csv`) with dynamic headers. Each one-off run appends two rows to each file: one for input and one for output. Keep in mind that training data is not added to the log, as the assumption is that your training baseline is what we compare against to measure drift.
+Results are stored in two CSV files (`COS_log.csv` & `EUC_log.csv`) with dynamic headers. Each one-off run appends one rows to each file. Keep in mind that training data is not added to the log, as the assumption is that your training baseline is what we compare against to measure drift.
 
 ### Format
 
 For the cosine similarity log:
+
 ```
-ID, DEPTH, TIMESTAMP, I/O TYPE, SEMANTIC ROLLING COS, SEMANTIC TRAINING COS, CONCEPT ROLLING COS...
+ID, TIMESTAMP, I/O TYPE, SEMANTIC ROLLING COS, SEMANTIC TRAINING COS, CONCEPT ROLLING COS...
 ```
+
 For the euclidean distance log:
+
 ```
-ID, DEPTH, TIMESTAMP, I/O TYPE, SEMANTIC ROLLING EUC, SEMANTIC TRAINING EUC, CONCEPT ROLLING EUC...
+ID, TIMESTAMP, I/O TYPE, SEMANTIC ROLLING EUC, SEMANTIC TRAINING EUC, CONCEPT ROLLING EUC...
 ```
+
 - Cosine similarities and euclidean distances are recorded per model and baseline type.
-- Additional metadata like `depth` and UUIDs are included for tracking.
-- UUIDs are shared for the input and output, so that you can review your input/output data logs to inspect which I/O pairs are causing drift.
-- Neither the log, nor the binary files, contain your users input or ai outputs. This data is not necessary to calculate drift, and its exclusion is an intentional choice for data privacy.
+- Additional metadata like ioType, date and UUIDs are included for tracking.
+- Neither the log, nor the binary files, contain your users input or AI outputs. This data is not necessary to calculate drift, and its exclusion is an intentional choice for data privacy.
 
 ```
-Note: if you add or remove model types to the tkyoDrift tracker, the log will break. Please ensure you clear any existing logs after altering the embedding model names. What we mean here, is that if you change your lexical model from "lexical" to "linguistic" when writing to the log, the makeLogEntry method of the Drift Class would work, but the log Parser would fail. 
+Note: if you add or remove model types to the tkyoDrift tracker, the log will break. Please ensure you clear any existing logs after altering the embedding model names. What we mean here, is that if you change your lexical model from "lexical" to "linguistic" when writing to the log, the makeLogEntry method of the Drift Class would work, but the log Parser would fail.
 
-Keep in mind, however, you can change models any time you like, though that will brick drift calculations for a different reason; your inputs/outputs will be embedded with dissimilar methods, which would lead to inaccurate drift calculations.
+Keep in mind, however, you can change models any time you like, though that will brick your drift calculations for a different reason; your inputs/outputs will be embedded with dissimilar methods, which would lead to inaccurate drift calculations.
 ```
 
 ## CLI Tools
@@ -149,7 +336,7 @@ TODO: Add the command we need people to enter to trigger this log here after the
 Parses `COS_log.csv` and displays violation counts and average cosine similarities over a selected number of days. Uses a color-coded table (green/yellow/red) to show severity of drift. Thresholds are set in this file, and should be adjusted to your expected precision needs.
 
 ```
-Note: The first record you enter into this system will always show that there is 0 drift when compared against the rolling data set. This is because the rolling dataset will be compared against itself at that point and there will be no drift to detect. This is a known issue, and was an intentional choice as the alternative would be to exclude a write to the `COS_log.csv` and `EUC_log.csv` logs on first write. 
+Note: The first record you enter into this system will always show that there is 0 drift when compared against the rolling data set. This is because the rolling dataset will be compared against itself at that point and there will be no drift to detect. This is a known issue, and was an intentional choice as the alternative would be to exclude a write to the `COS_log.csv` and `EUC_log.csv` logs on first write.
 
 If this bothers you, you can remove line 2 from the COS and EUC logs after you use this system at least twice.
 ```
@@ -158,29 +345,28 @@ If this bothers you, you can remove line 2 from the COS and EUC logs after you u
 
 ![An image of the print Scalar CLI tool's output, displaying metric comparisons between the training and rolling baseline values. For example, avgWordLength for inputs has a mean of 4.82 characters in the training data, but a mean of 4.49 characters in the rolling data, leading to a mean delta of -0.34, and a PSI value of 0.017 which represents stable populations between the two. ](printScalarCLI.png)
 
-This tool parses the scalar jsonl files to calculate scalar distributions across the training and rolling datasets and delta mean and delta standard deviation between the two distributions. Uses a color-coded table (green/yellow/red) to show severity of drift. Thresholds are set in this file, and should be adjusted to your expected precision needs.
+This tool parses the scalar jsonl files to calculate scalar distributions across the training and rolling datasets and delta mean and delta standard deviation between the two distributions. L2 norm is an embedding model specific metric, and will be captured once per model while all others are input specific and are captures once per input. Uses a color-coded table (green/yellow/red) to show severity of drift. Thresholds are set in this file, and should be adjusted to your expected precision needs.
 
 The scalar metrics the system is currently tracking are listed below:
 
-| Metric               | Description                                                   |
-|----------------------|---------------------------------------------------------------|
-| `norm`               | Vector magnitude (captures changes in embedding length/energy)|
-| `textLength`         | Raw character count of the input/output text                  |
-| `tokenLength`        | Number of tokens (based on model tokenizer)                   |
-| `entropy`            | Character-level entropy (measures information density)        |
-| `avgWordLength`      | Average word length (indicates language complexity)           |
-| `punctuationDensity`| Ratio of punctuation to characters (captures tone/stylistics) |
-| `uppercaseRatio`     | Ratio of uppercase letters (detects emphasis or acronyms)     |
+| Metric               | Description                                                    |
+| -------------------- | -------------------------------------------------------------- |
+| `norm`               | Vector magnitude (captures changes in embedding length/energy) |
+| `textLength`         | Raw character count of the input/output text                   |
+| `entropy`            | Character-level entropy (measures information density)         |
+| `avgWordLength`      | Average word length (indicates language complexity)            |
+| `punctuationDensity` | Ratio of punctuation to characters (captures tone/stylistics)  |
+| `uppercaseRatio`     | Ratio of uppercase letters (detects emphasis or acronyms)      |
 
 ```
-Note: Without batch embedding your training data, you will be unable to view scalar metrics. However, we will still collect scalar metrics for your rolling data in the event you add training data at a later time.
+Note: Without batch embedding your training data, scalar metric comparison will run in hybrid mode, which compares the oldest 10,000 inputs against the most recent 1,000 inputs from the rolling file. This simulates a baseline when you haven't provided one through the training batch embedding process.
 ```
 
-# Architecture
+# Architecture Decisions
 
 ### Embedding Models
 
-TKYO Drift uses remote embedding models on HuggingFace.co for inference using the Xenova Transformers library in javascript or the python native hugging face library in python. By default, the system operates in JavaScript using a lightweight transformer pipeline, with Python scripts injected as required to improve speed when performing batched operations. The python equivalent embedding pipeline allows for CPU usage by default if your system has the appropriate CUDA drivers.
+TKYO Drift uses remote embedding models on HuggingFace.co for inference using the Xenova Transformers library in javascript or the python native hugging face library in python. By default, the system operates in JavaScript using a lightweight transformer pipeline, with Python scripts injected as required to improve speed when performing batched operations. The python equivalent embedding pipeline allows for GPU usage by default if your system has the appropriate NVIDIA CUDA drivers.
 
 - `all-MiniLM-L12-v2`: Used for semantic drift or changes in tone or communication style.
 
@@ -194,14 +380,19 @@ TKYO Drift uses remote embedding models on HuggingFace.co for inference using th
 
   https://huggingface.co/Xenova/all-MiniLM-L6-v2
 
+While L6 is a subset of L12, it is also the case that lexical drift is a subset of semantic drift. This model can be disabled if you believe that MiniLM-L12 is comprehensive enough to provide drift tracking for both types. This speeds up one-off and batched operations by about 10%.
 
-Note that while L6 is a subset of L12, it is also the case that lexical drift is a subset of semantic drift. This model can be disabled if you believe that MiniLM-L12 is comprehensive enough to provide drift tracking for both types. This speeds up one-off and batched operations by about 10%.
+You might be thinking: "Can I serialize a loaded model to disk and reuse it?"
+
+In practice, Hugging Face models are already cached locally in ~/.cache/huggingface (or your platform's path) but their in-memory representations (tokenizer + model) can't be deserialized efficiently from Node in a raw form.
+
+So no, there's no good way to "freeze" a pipeline() and reload it faster... unless... you download the `.safetensor` and run it locally.
 
 ### Xenova/Hugging Face Transformer Library
 
-While the Xenova transformer library is a javascript equivalent of the Hugging Face python transformer library, the primary difference is that the former was made for JS while the latter was made for Python. The HF library allows for GPU acceleration, which is why it was chosen for batched calls. In either case, we are using the same transformer library for the same purpose. As such, Xenova/Hugging Face Transformers were chosen as the preferred choice of transformer libraries because:
+While the Xenova transformer library is a javascript equivalent of the Hugging Face python transformer library, the primary difference is that the former was made for JS by the xenova team while the latter was made for Python by huggingface themselves. The HF library allows for GPU acceleration, which is why it was chosen for batched calls. In either case, we are using the same transformer library for the same purpose. As such, Xenova/Hugging Face Transformers were chosen as the preferred choice of transformer libraries because:
 
-- Embedding models are quite large, and including a wget or some other form of downloading models to run locally would require dealing with user authentication for the huggingface.com site, which we wanted to avoid. 
+- Embedding models are quite large, and including a wget or some other form of downloading models to run locally would require dealing with user authentication for the huggingface.com site, which we wanted to avoid.
 - People have good internet now, mostly, so we can get away with streaming the model conclusions to the workflow environment without dealing with a local model.
 - Using wasm for the embedding pipeline lets people hot swap models without having to replace safetensors.
 
@@ -210,14 +401,15 @@ While the Xenova transformer library is a javascript equivalent of the Hugging F
 Drift is detected across combinations of:
 
 - `modelType`: semantic, concept, lexical
-- `ioType`: input, output
+- `ioType`: a string you specify
 - `baselineType`: rolling, training
 
-This results in twelve cosine similarity and euclidean distance comparisons (assuming you use the default models) for each tkyoDrift.js function call.
+This results in six cosine similarity and euclidean distance comparisons (assuming you use the default models) for each ioType you declare. Since all drift calculations are performed against the same ioType, each specified type will increase your file counts linearly.
+
 - All embeddings are pooled across all input tokens to get mean values from the input and normalized for all models except for the conceptual drift type.
 - Models are loaded sequentially and cached globally to reduce loading time.
 
-Note that once the execution context window closes for the processing I/O pair, models are naturally unloaded. Unless you feel inclined to download and store the models locally in your production pipeline, this is a necessary and unavoidable ~200ms workflow speed penalty.
+Note that once the execution context window closes for the processing I/O pair, models are naturally unloaded. Unless you feel inclined to download and store the models locally in your production pipeline, this is a necessary and unavoidable ~500ms workflow speed penalty. See the Production Impact section above for more information on how to minimize this impact.
 
 ```
 Drift detection in the scalar metrics is ONLY available when a training dataset is provided, as scalar metrics are comparisons in distribution shape. In other words, without a training distribution to compare against the rolling distribution, there is no comparison to make.
@@ -227,53 +419,52 @@ Drift detection in the scalar metrics is ONLY available when a training dataset 
 
 - `Rolling`: A sliding baseline using the most recent N (default 1,000) examples.
 
-The rolling baseline represents the accumulation of inputs and outputs as they are triggered by the production pipeline. As I/O pairs are dispatched to the drift analysis workflow, each I/O pair is saved to the rolling baseline file. When drift calculations are generated, they exclude the newest I/O pair for that individual calculation but will include them in all subsequent operations. The total number of I/O pairs to be included in drift analysis is a configurable variable located in the pythonHNSW.py file. 
+The rolling baseline represents the accumulation of inputs and outputs as they are triggered by the production pipeline. As inputs are dispatched to the drift analysis workflow, each input is saved to the rolling baseline file. When drift calculations are generated, they exclude the newest input for that individual calculation but will include them in all subsequent operations. If you are feeling brave, you can update this value in both `pythonHNSW.py` and `loadScalarMetrics.js`.
 
 - `Training`: A fixed baseline built once from a full dataset.
 
-The training baseline represents the set of inputs used to generate the initial model AI responses, which are ingested by running the 'tkyoDriftSetTraining.py' script. This script performs a batch analysis of each I/O pair used in the training set and creates an artificially 'locked' training file that can not/will not be be appended to over time. Theoretically, you should only need to update this when you have retrained you model.
+The training baseline represents the set of inputs used to generate the initial model AI responses, which are ingested by running the 'tkyoDriftSetTraining.py' script. This script performs a batch analysis of a single input column used in the training set and creates an artificially 'locked' training file that can not/will not be be appended to over time. Theoretically, you should only need to update this when you have retrained you model, but you may need to run it once for each ioType in your training data.
 
 - `Hybrid`: Use the rolling file to provide oldest K (default 10,000) and newest N (default 1,000) simultaneously.
 
 In the event that there is no training data supplied to the system, the Drift analyzer will use the oldest K values entered into the rolling file to represent mock 'training' data, while the newest K values represent the 'rolling' data. This allows us to compare drift against an anchor point to see drift over time, while still having a rolling window to see shock impacts to the system caused by new concepts/semantics/lexicon.
 
-
 ### Binary Embedding Storage
 
-Embeddings are saved in `.bin` files using float32 for efficient storage. This minimizes disk I/O and enables fast appending.
+Embeddings are saved in `.bin` files using float32 for efficient storage. We chose to make a custom bin writer and reader because bins have tiny overhead and force us to drop repeating characters like object braces and array brackets. Since this system is intended to work with potentially millions of embeddings, this minimizes disk I/O and enables fast appending.
 
 - Each file is named:  
   `{modelType}.{ioType}.{baselineType}.bin`
-  
-This yields `(models * I/Os * baselines)` file combinations, and at the minimum should represent two files if you are using a single drift model for an I/O pair with only the rolling baseline. By default this library is configured to run with 3 drift types for an I/O pair, and will have 6 rolling files. This would become 12 should you upload training data. 
 
-At the time of writing, the default models in this library have either 768 or 384 dimensions per input.  
+This yields `(models * I/Os * baselines)` file combinations, and at the minimum should represent one file if you are using a single drift model for a single ioType using only the rolling baseline.
 
-| Model                          | Purpose                         | Dimensions | Bytes per Input (float16) | File Size (10,000 inputs) |
-|-------------------------------|----------------------------------|------------|----------------------------|----------------------------|
-| `Xenova/all-MiniLM-L12-v2`    | Semantic (communication method) | 384        | 768 bytes                 | ~7.5 MB                   |
-| `Xenova/e5-base`              | Concept (communication intent)  | 768        | 1,536 bytes               | ~15.0 MB                  |
-| `Xenova/all-MiniLM-L6-v2`     | Lexical (syntax)                | 384        | 768 bytes                 | ~7.5 MB                   |
+At the time of writing, the default models in this library have either 768 or 384 dimensions per input.
+
+| Model                      | Purpose                         | Dimensions | Bytes per Input (float16) | File Size (1,000,000 inputs) |
+| -------------------------- | ------------------------------- | ---------- | ------------------------- | ---------------------------- |
+| `Xenova/all-MiniLM-L12-v2` | Semantic (communication method) | 384        | 768 bytes                 | ~750 MB                      |
+| `Xenova/e5-base`           | Concept (communication intent)  | 768        | 1,536 bytes               | ~1.5 GB                      |
+| `Xenova/all-MiniLM-L6-v2`  | Lexical (syntax)                | 384        | 768 bytes                 | ~750 MB                      |
 
 Note: 1 MB = 1,048,576 bytes (binary MB), but here we're rounding to 1 MB = 1,000,000 bytes for simplicity.
 
-Scalar files are negligibly large, and even with 1 million records, they should take less than 250 MBs and the Log files themselves are miniscule. 
+Scalar files are negligibly large, and even with 1 million records, they should take less than 250 MBs and the Log files themselves are miniscule.
 
 ```
-The rolling files have no upper limit on their size, and will require manual pruning eventually depending on your workflow's throughput. Incidentally, if you do not have access to your training data (you may be using a 3rd party model without a published data set) you may benefit from renaming your rolling files to training files after you have accumulated 10,000 entries.
+The rolling files have no upper limit on their size, and will require manual pruning eventually depending on your workflow's throughput. Incidentally, if you do not have access to your training data (you may be using a 3rd party model without a published data set) you may benefit from renaming your rolling files to training files after you have accumulated at least 10,000 entries.
 ```
 
-***Write operations are done primarily to the rolling file set, as training files are explicitly and intentionally excluded from write operations outside of the batched training embedding pipeline.***
+**_Write operations are performed on only the rolling file set, as training files are explicitly and intentionally excluded from write operations outside of the batched training embedding pipeline._**
 
 This intentional decision reflects the nature that training datasets represent a fixed point in time, and should not be modified after being ingested. Throughout this codebase, there are checks for a model's baseline type, and if that baseline is set to `training', write operations are skipped.
 
-As a way of making this system work where there is no training data provided, the system will attempt to use hybrid mode as several models use the rolling file path locations as replacements for the training file paths. 
+As a way of making this system work where there is no training data provided, the system will attempt to use hybrid mode as several models use the rolling file path locations as replacements for the training file paths.
 
-In hybrid mode, because the first N vectors are considered training vectors, and the last K vectors are considered rolling vectors, there will be a duration of time that training and rolling datasets will be equivalents. For example, when the system only contains 1500 vectors, all 1500 will be considered `training` (training defaults are first 10,000) and the most recent 1000 would be considered `rolling`.
+In hybrid mode, because the first N vectors are considered training vectors, and the last K vectors are considered rolling vectors, there will be a duration of time that training and rolling datasets will be equivalents. For example, when the system only contains 1500 vectors, all 1500 will be considered `training` and the most recent 1000 would be considered `rolling`.
 
 ### IO Write/Read Methods
 
-File writing/reading is performed using `fs.promises.writeStream` and `fs.promises.readStream` due to the obscene number of floats we need to read, parse and then calculate against, which necessitates that vectors be constructed during the read process to avoid memory overflows. This is an intentional tradeoff of speed for deployability. If you know your system has the memory to spare, IO ops can be improved by replacing write/read streams with loads-to-memory.
+File writing/reading is performed using `fs.promises.writeStream` and `fs.promises.readStream` due to the obscene number of floats we need to read, parse and then calculate against, which necessitates that vectors be constructed during the read process to avoid memory overflows. This is an intentional tradeoff of speed for deployability. If you know your system has the memory to spare, IO ops can be improved by replacing write/read streams with loads-to-memory. This would be done in the `DriftModel.js` file.
 
 ## HNSW Indexing
 
@@ -285,34 +476,44 @@ HNSW (Hierarchical Navigable Small World) allows us to support approximate neare
 - N(logN) lookup across (theoretically) millions of embeddings.
 - Tunable accuracy and recall settings.
 
+HNSW creation is factored into the `readFromBin()` model class method (which calls on `pythonHNSW.py`), and is fast enough that we re-calculate the HNSW on every read.
+
+```
+If this feels inefficient to you, this section of code can be refactored to create an HNSW index file to be loaded. @ 50,000 embeddings, building the HNSW  added 5ms to the process so we opted not take this step. 
+```
+
 # The Math
 
 The core calculation behind drift tracking is **cosine similarity**, which evaluates the angle between two vectors in high-dimensional space, ignoring their magnitude. This is ideal for comparing semantic or conceptual distance between two pieces of text.
 
 ## Cosine Similarity & Euclidean Distance
 
-Cosine similarity between two vectors **A** and **B** is calculated as:
+The cosine similarity between two vectors **A** and **B** is calculated as:
+
+```cosine_similarity(A, B) = (A · B) / (||A|| * ||B||)```
 
 Where:
+
 - `A · B` is the dot product of vectors A and B.
 - `||A||` is the magnitude (L2 norm) of vector A.
 - `||B||` is the magnitude of vector B.
 
 The result is a value between -1 and 1. For normalized embedding vectors (as used here), the output is always between 0 and 1:
+
 - `1.0` → Identical direction (no drift)
 - `0.0` → Orthogonal (maximum drift)
 
-Normalization ensures magnitude doesn’t influence the result, so only the *direction* of the vector matters. Additionally, we are calculating the Euclidean Distance. This metric is not scale-invariant and is typically larger in magnitude. It’s useful in conjunction with cosine similarity to detect both directional and magnitude-based drift.
+Normalization ensures magnitude doesn’t influence the result, so only the _direction_ of the vector matters. Additionally, we are calculating the Euclidean Distance. This metric is not scale-invariant and is typically larger in magnitude. It’s useful in conjunction with cosine similarity to detect both directional and magnitude-based drift.
 
 ## What B Represents
 
-In the context of TKYO Drift, **B** is the *baseline vector* against which a new embedding (**A**) is compared. It represents the average of historical embeddings from either:
+In the context of TKYO Drift, **B** is the _baseline vector_ against which a new embedding (**A**) is compared. It represents the average of historical embeddings from either:
 
 - The **rolling baseline**, which reflects the most recent N inputs/outputs in production.
 - The **training baseline**, which reflects embeddings generated from your original training dataset.
 - Or both (in hybrid mode), where the system simulates a static baseline from the start of the rolling file.
 
-This averaged baseline acts as a reference point. If the direction of the new embedding (A) starts to diverge from B, it indicates a potential drift in communication, concept, or syntax.
+This averaged baseline acts as a reference point. If the direction of the new embedding (A) starts to diverge from (B), it indicates a potential drift in communication, concept, or syntax.
 
 ## Centroid Calculation
 
@@ -328,9 +529,7 @@ This system uses `(num_of_clusters = int(np.sqrt(num_vectors / 2)))` to determin
 
 ## Scalar Metrics
 
-In addition to vector-based drift (cosine similarity and Euclidean distance), TKYO Drift also tracks **scalar metrics**—individual numerical features extracted from the raw text of your inputs and outputs. These scalar values help capture shifts in text structure, tone, or complexity that may not be reflected in semantic embeddings.
-
-Scalar metrics are only compared when a **training baseline** is available. Without this baseline, we cannot evaluate how the distribution of scalar values has changed over time.
+In addition to vector-based drift (cosine similarity and Euclidean distance), TKYO Drift also tracks **scalar metrics**, or individual numerical features extracted from the raw text of your inputs. These scalar values help capture shifts in text structure, tone, or complexity that may not be reflected in semantic embeddings.
 
 ### How Are They Calculated?
 
@@ -338,11 +537,10 @@ Each metric is computed as follows:
 
 - `norm`: L2 norm (vector magnitude) from the output embedding.
 - `textLength`: Length of the raw string.
-- `tokenLength`: Number of tokens from the model tokenizer.
 - `entropy`: Shannon entropy over character frequencies.
 - `avgWordLength`: Mean word length based on whitespace splitting.
-- `punctuationDensity`: `punctuation_count / total_chars`.
-- `uppercaseRatio`: `uppercase_count / total_chars`.
+- `punctuationDensity`: punctuation count divided by total chars.
+- `uppercaseRatio`: uppercase count divided by total chars.
 
 These are implemented in both JS (for rolling ingestion) and Python (for training ingestion) and saved alongside vector data.
 
@@ -352,39 +550,38 @@ Scalar metrics help detect **non-semantic drift**. For example:
 
 - A spike in `uppercaseRatio` may indicate aggressive or stylized tone.
 - A drop in `entropy` could mean the system is outputting simpler or repetitive responses.
-- A change in `tokenLength` may point to output truncation or verbosity.
+- A change in `textLength` may point to output truncation or verbosity.
 
-In general, scalar drift reveals changes in *how* your model or users are communicating, not just *what* it's communicating.
+In general, scalar drift reveals changes in _how_ your model or users are communicating, not just _what_ it's communicating.
 
 ### Comparison Logic
 
 Drift is measured by comparing the **mean** and **standard deviation** of each metric between the training and rolling baselines.
 
 For each metric:
+
 ```
 meanDelta = rollMean - trainMean
 stdDelta  = rollStd  - trainStd
 ```
-These deltas are printed in the CLI printout with color-coded thresholds (green/yellow/red) to indicate severity.
 
-### PSI Values (Population Stability Index)
+These deltas are printed in the CLI printout with color-coded thresholds (green/yellow/red) to indicate severity using the distribution's standard deviation for color coding. Within 1 stDev is green, within 2 yellow, outside of 2 will be red.
+
+### PSI (Population Stability Index) Values
 
 TKYO Drift calculates the **Population Stability Index (PSI)** for all scalar metrics when comparing rolling data against the training baseline. PSI quantifies how much a distribution has shifted over time, and is commonly used in production monitoring to detect silent model degradation.
 
-For each scalar metric, the PSI score is computed using pre-defined bins and normalized frequency distributions from both the rolling and training datasets.
+For each scalar metric, the PSI score is computed using automatically configured  bins and normalized frequency distributions from both the rolling and training datasets.
 
 The PSI interpretation follows standard thresholds:
 
 | PSI Value | Interpretation                  |
-|-----------|---------------------------------|
+| --------- | ------------------------------- |
 | < 0.1     | No significant drift            |
 | 0.1–0.25  | Moderate shift; monitor closely |
-| > 0.25    | Major shift; likely model drift |
+| > 0.25    | Major shift; model drift likely |
 
-These scores are included in the CLI drift output and provide a statistically grounded way to monitor changes in features like entropy, token length, or word complexity — even if the semantic embeddings remain stable.
-
-TKYO Drift uses this in tandem with mean and standard deviation deltas to give a robust picture of scalar drift.
-
+These scores are included in the scalar metric CLI drift output and provide a statistically grounded way to monitor changes in features like entropy, token length, or word complexity — even if the semantic embeddings remain stable.
 
 # Future Iterations
 
@@ -392,7 +589,7 @@ For this project there are a number of ways this platform could be made better, 
 
 ### Rolling Data Selection
 
-The rolling file currently uses a fixed number of records when loaded during the readFromBin method on the DriftModel class, this fixed number may not be a flexible enough method of selecting the number of records to compare for rolling drift. It would be an improvement to modify this so that it uses entries from the last N days instead. 
+The rolling file currently uses a fixed number of records when loaded during the readFromBin method on the DriftModel class, this fixed number may not be a flexible enough method of selecting the number of records to compare for rolling drift. It would be an improvement to modify this so that it uses entries from the last N days instead.
 
 Building this would require adding a date to the binary file write method to store when a file was added, or replacing the binary file writer entirely and switching to a different file storage format. Regardless, at the time of this readme writeup, there is no date associated with stored vectors and so there is no way to have the rolling file use the last N days of records instead of a fixed count.
 
@@ -402,11 +599,7 @@ The current implementation sets K using a heuristic: K = int(sqrt(num_vectors / 
 
 Implementing the elbow method would require running KMeans multiple times and analyzing metrics like SSE or silhouette scores. Given our real-time and batch constraints, we avoid this due to diminishing accuracy gains (often logarithmic) versus increased computational cost (often linear to exponential with larger datasets).
 
-### Depth Tracking
-
-While being able to track multiple chains of thought in your AI workflow is an important part of measuring drift, the current implementation of depth tracking suffers from a critical drawback in that COS similarity, EUC distance, and scalar metrics are NOT calculated for each depth band. 
-
-Resolving this would require a major refactor of the calculation of drift metrics so that they only compare against other entries of the same depth. Alternatively, it would require writing to individual logs for each depth. In any case, the current functionality may unintentionally pollute the drift scores as I/O from different depths are included in the calculations for COS similarity/EUC distance/Scalar metrics.
+However, since this value can be derived during the batch ingestion, when performance is not a priority, you could add it there. :)
 
 ### Python vs Javascript
 
@@ -414,7 +607,7 @@ This project was initially built as a pure javascript project to enable wider de
 
 What this means is that the tkyoDriftSetTraining.py file and the tkyoDrift.js processes are functionally duplicates of each other except that the former is explicitly meant to be called once for a batch, while the later is meant to be invoked on every new input.
 
-This is fine as it is, but since many javascript libraries are just python scripts wearing a disguise, it would be ideal to rebuild this entire platform in python with a javascript NPM package to install it, and a javascript function hook to pass data into it. This would allow this system to avoid unnecessary conversion from javascript into python to execute AI embeddings, calculate K means, or generate the HNSW index.
+This is fine as it is, but since many javascript libraries are just python scripts wearing in disguise, it would be ideal to rebuild this entire platform in python with a javascript NPM package to install it, and a javascript function hook to pass data into it. This would allow this system to avoid unnecessary conversion from javascript into python to execute AI embeddings, calculate K means, or generate the HNSW index.
 
 ### PSI Logging
 
@@ -422,25 +615,31 @@ At the time of writing, this project does not log PSI values to a csv file. This
 
 Fixing this would involve adding a cronjob to compare scalar metrics on an interval, or adding a counter of some sort and triggering a scalar comparison every N (10? 100?) new inputs. If the output of this comparison is sent to a log instead of the CLI, it would be consumable by external tools.
 
+Theoretically the data is still accessible in the JSONL files, but there are many of those, and rigging them together to get a complete picture is tedious.
+
 ### Cloud Based embedding services
 
-Waiting is pain, and embedding hundreds of thousands of inputs over and over again can take a long time. Not to mention that larger models take up a ton of space (1 mill I/Os is like 20 gbs). This whole platform could be a paid service where people upload their I/Os and you keep their embeddings remotely.
+Waiting is pain, and embedding hundreds of thousands of inputs over and over again can take a long time. Not to mention that larger models take up a ton of space (1 mill inputs for 3 models for both baselines is like 6 gbs). This whole platform could be a paid service where people upload their I/Os and you keep their embeddings remotely.
 
-Not only that, but there is a vast range of data visualizations that could be made, warning and alerts, recommendations based on what flags are getting triggered, etc. 
+Not only that, but there is a vast range of data visualizations that could be made, warning and alerts, recommendations based on what flags are getting triggered, etc.
 
-This would involve creating a whole front end with user login, a backend API to receive one off calls and a file upload system to receive massive training data files. This would be a fun project in it's own right, but obviously involves cloud server costs to rapidly process embeddings. If you do decide to make a business out of this, give us a call, we would love to help. 
+This would involve creating a whole front end with user login, a backend API to receive one off calls and a file upload system to receive massive training data files. This would be a fun project in it's own right, but obviously involves cloud server costs to rapidly process embeddings. If you do decide to make a business out of this, give us a call, we would love to help.
 
 ### Multi-Modality
 
-This project is only developed to be able to ingest text data, but there are many AI workflows out there. A future iteration of this project could include text2img, img2img, text2video, img2video, etc. 
+This project is only developed to be able to ingest text data, but there are many AI workflows out there. A future iteration of this project could include text2img, img2img, text2video, img2video, etc.
 
-Most of the ground work for this is already done, but new embedding models specifically designed for those types of workflows would need to be incorporated, along with file type handling which is missing in the main workflow. (If you pass anything other than text into the main or batch embedding function, they break.)
+Most of the ground work for this is already done, but new embedding models specifically designed for those types of workflows would need to be incorporated, along with file type handling which is missing in the main workflow. (As in, if you pass anything other than text into the main or batch embedding function, they break.)
 
 ### More Math
 
-We are currently calculating a number of metrics from both individual vectors as well as populations across the training and rolling data sets. There is room for improvement, however, in that there are additional drift measures such as KL divergence and Earth Movers distance that would be useful to calculate in this workflow. 
+We are currently calculating a number of metrics from both individual vectors as well as populations across the training and rolling data sets. There is room for improvement, however, in that there are additional drift measures such as KL divergence and Earth Movers distance that would be useful to calculate in this workflow.
 
 It is our opinion that either of these could be added to the tkyoDrift analysis with minimal effort, as the `tkyoDrift` main logic `tkyoDriftSetTraining.py` batch embedding logic both capture scalar metrics for population comparisons already.
+
+### Testing Battery
+
+Its worth building. We should have. We didn't.
 
 ## Contributing
 
@@ -452,7 +651,7 @@ If you'd like to propose a feature, feel free to open a discussion or ticket.
 
 ## License
 
-This project is licensed under the [MIT License](LICENSE).
+This project is licensed under the [MIT License](LICENSE). Go nuts.
 
 ## Acknowledgments
 
@@ -463,6 +662,7 @@ Milti, Wing, Monique, Chris and Anthony
 Check out our other projects and send us a message if you would like to collaborate.
 
 Big thanks to the folks behind:
+
 - [Hugging Face Transformers](https://huggingface.co)
 - [Xenova Transformers](https://xenova.github.io/)
 - [Open Source Labs](https://github.com/oslabs-beta)

--- a/tkyo-drift/tkyoDrift.js
+++ b/tkyo-drift/tkyoDrift.js
@@ -218,8 +218,22 @@ export default async function tkyoDrift(text, ioType) {
 }
 
 // TODO: Remove hardcoded input/output values
-// const input =
-//   'Describe how the context surrounding the shape of a vector determines how much drift might occur when analyzed using cosine similarity.';
-// const output = 'I am sorry, but I do know know how to respond to this request.';
+const input = 'How do the properties of the catalyst and the reaction conditions affect the rate of a heterogeneous catalytic reaction? Provide a detailed explanation with examples.';
+const output = `**Solution:**
+The rate of a heterogeneous catalytic reaction is governed by **catalyst properties** and **reaction conditions**:
+
+1. **Catalyst Properties:**
+- **Surface Area:** Higher surface area (e.g., finely divided iron in the Haber-Bosch process) increases active sites, boosting reaction rate.
+- **Active Site Density:** More sites per unit area enhance adsorption (e.g., Co catalysts in Fischer-Tropsch synthesis).
+- **Structure/Morphology:** Porous or nanostructured catalysts (e.g., zeolites) improve reactant access and selectivity.
+- **Electronic Properties:** Oxidation state and electron density influence adsorption strength (e.g., Au nanoparticles for alcohol oxidation).
+
+2. **Reaction Conditions:**
+- **Temperature:** Increases rate by raising kinetic energy but may deactivate catalysts via sintering (e.g., metal catalysts at high temps).
+- **Pressure:** Enhances reactant adsorption (e.g., high pressure in Haber-Bosch for N₂/H₂ adsorption on Fe).
+- **Reactant Concentration:** Higher concentration increases collision frequency with active sites.
+- **Promoters/Inhibitors:** Promoters like Al₂O₃ in Haber-Bosch improve catalyst efficiency; inhibitors block sites (e.g., sulfur poisoning in Ni catalysts).
+
+Optimizing these factors ensures efficient catalysis, balancing activity and stability for industrial applications like ammonia synthesis or hydrocarbon production.`;
 // await tkyoDrift(input, 'problem');
 // await tkyoDrift(output, 'solution');

--- a/tkyo-drift/tkyoDrift.js
+++ b/tkyo-drift/tkyoDrift.js
@@ -218,8 +218,8 @@ export default async function tkyoDrift(text, ioType) {
 }
 
 // TODO: Remove hardcoded input/output values
-const input =
-  'Describe how the context surrounding the shape of a vector determines how much drift might occur when analyzed using cosine similarity.';
-const output = 'I am sorry, but I do know know how to respond to this request.';
-await tkyoDrift(input, 'problem');
-await tkyoDrift(output, 'solution');
+// const input =
+//   'Describe how the context surrounding the shape of a vector determines how much drift might occur when analyzed using cosine similarity.';
+// const output = 'I am sorry, but I do know know how to respond to this request.';
+// await tkyoDrift(input, 'problem');
+// await tkyoDrift(output, 'solution');

--- a/tkyo-drift/tkyoDriftSetTraining.py
+++ b/tkyo-drift/tkyoDriftSetTraining.py
@@ -13,7 +13,7 @@ import json
 # Allow error logging for testing purposes
 import traceback
 
-def tkyoDriftSetTraining(data_set_Path, input_name, output_name):
+def tkyoDriftSetTraining(data_set_Path, io_type, io_type_name):
 
     # Starts the total function timer
     startTotal = time.perf_counter()
@@ -25,30 +25,24 @@ def tkyoDriftSetTraining(data_set_Path, input_name, output_name):
         "lexical": "sentence-transformers/all-MiniLM-L6-v2",
     }
 
-    IO_TYPES = {
-        "input": input_name,
-        "output": output_name,
-    }
 
     # Call once per I/O type to extract shared scalar metrics
-    for io_type, column_name in IO_TYPES.items():
-        print(f"Building scalar metrics for {io_type}")
-        write_shared_scalar_metrics(data_set_Path, io_type, column_name)
+    print(f"Building scalar metrics for {io_type} as {io_type_name}.")
+    write_shared_scalar_metrics(data_set_Path, io_type, io_type_name)
 
     # Iterate through models dictionary
     for model_type, model_name in MODELS.items():
-        for io_type, io_type_name in IO_TYPES.items():
-            pythonTrainingEmb.trainingEmb(
-                model_type=model_type,
-                model_name=model_name,
-                data_path=data_set_Path,
-                io_type=io_type,
-                io_type_name=io_type_name,
-            )
+        pythonTrainingEmb.trainingEmb(
+            model_type=model_type,
+            model_name=model_name,
+            data_path=data_set_Path,
+            io_type=io_type,
+            io_type_name=io_type_name,
+        )
 
     # Ends timing for the entire function
     endTotal = time.perf_counter()
-    print(f"Elapsed: {endTotal - startTotal:.6f} seconds")
+    print(f"Full embedding run for {io_type} completed in: {endTotal - startTotal:.2f} seconds")
 
     return {"status": "ok", "message": "Training completed"}
 
@@ -60,7 +54,7 @@ if __name__ == "__main__":
         print(
             json.dumps(
                 {
-                    "error": "Usage: python3 pythonHNSW.py <io_type> <model_type> <query_json> <baseline_type>"
+                    "error": "Usage: python3 tkyoDriftSetTraining.py <dataset_path> <io_type> <io_type_name>"
                 }
             )
         )

--- a/tkyo-drift/tkyoDriftSetTraining.py
+++ b/tkyo-drift/tkyoDriftSetTraining.py
@@ -48,7 +48,7 @@ def tkyoDriftSetTraining(data_set_Path, input_name, output_name):
 
     # Ends timing for the entire function
     endTotal = time.perf_counter()
-    print(f"Elapsed: {endTotal - startTotal:.6f} seconds")
+    print(f"Full embedding run for all I/Os completed in: {endTotal - startTotal:.2f} seconds")
 
     return {"status": "ok", "message": "Training completed"}
 

--- a/tkyo-drift/tkyoDriftSetTrainingHook.js
+++ b/tkyo-drift/tkyoDriftSetTrainingHook.js
@@ -53,8 +53,6 @@ const tkyoDriftSetTraining = async (
 
 // TODO Remove hardcoded path, input name, & output name
 const dataSetPath = './data';
-const inputName = 'problem';
-const outputName = 'solution';
-// input_name = "['conversations'][0]['value']"
-// output_name = "['conversations'][1]['value']"
+const inputName = 'question';
+const outputName = 'answer';
 tkyoDriftSetTraining(dataSetPath, inputName, outputName);

--- a/tkyo-drift/tkyoDriftSetTrainingHook.js
+++ b/tkyo-drift/tkyoDriftSetTrainingHook.js
@@ -53,6 +53,6 @@ const tkyoDriftSetTraining = async (
 
 // TODO Remove hardcoded path, input name, & output name
 const dataSetPath = './data';
-const inputName = 'question';
-const outputName = 'answer';
+const inputName = 'problem';
+const outputName = 'solution';
 tkyoDriftSetTraining(dataSetPath, inputName, outputName);

--- a/tkyo-drift/tkyoDriftSetTrainingHook.js
+++ b/tkyo-drift/tkyoDriftSetTrainingHook.js
@@ -1,18 +1,14 @@
 import { spawn } from 'child_process';
 
-const tkyoDriftSetTraining = async (
-  dataSetPath,
-  inputName = 'input',
-  outputName = 'output'
-) => {
+const tkyoDriftSetTraining = async (dataSetPath, ioType, ioTypeName) => {
   try {
     return new Promise((resolve, reject) => {
       const pyProg = spawn('python3', [
         '-u',
         './tkyoDriftSetTraining.py',
         dataSetPath,
-        inputName,
-        outputName,
+        ioType,
+        ioTypeName,
       ]);
 
       let result = '';
@@ -53,8 +49,8 @@ const tkyoDriftSetTraining = async (
 
 // TODO Remove hardcoded path, input name, & output name
 const dataSetPath = './data';
-const inputName = 'problem';
-const outputName = 'solution';
-// input_name = "['conversations'][0]['value']"
-// output_name = "['conversations'][1]['value']"
-tkyoDriftSetTraining(dataSetPath, inputName, outputName);
+// First call: embed the "problem" column as "problem"
+await tkyoDriftSetTraining(dataSetPath, 'problem', 'problem');
+
+// Second call: embed the "solution" column as "solution"
+await tkyoDriftSetTraining(dataSetPath, 'solution', 'solution');

--- a/tkyo-drift/util/DriftModel.js
+++ b/tkyo-drift/util/DriftModel.js
@@ -7,12 +7,11 @@ import { pipeline } from '@xenova/transformers';
 import { OUTPUT_DIR, MODEL_CACHE } from '../tkyoDrift.js';
 
 export class DriftModel {
-  constructor(modelType, modelName, ioType, baselineType, depth = 0) {
+  constructor(modelType, modelName, ioType, baselineType) {
     this.baselineType = baselineType;
     this.modelType = modelType;
     this.modelName = modelName;
     this.ioType = ioType;
-    this.depth = depth;
     this.distance = null;
     this.embedding = null;
     this.byteOffset = null;

--- a/tkyo-drift/util/DriftModel.js
+++ b/tkyo-drift/util/DriftModel.js
@@ -121,13 +121,12 @@ export class DriftModel {
       this.embedding = result.data;
 
       // Check if result.data exists and is a numeric array
-    if (!(this.embedding instanceof Float32Array)) {
+      if (!(this.embedding instanceof Float32Array)) {
         throw new Error('Embedding result is not a valid Float32Array.');
-      } 
+      }
       // Check if the embedding is empty
       if (this.embedding.length === 0) {
-        throw new Error(
-          'Embedding array is empty.');
+        throw new Error('Embedding array is empty.');
       }
 
       // Save dimensions to object (the actual vector dim is at position 1)
@@ -135,7 +134,6 @@ export class DriftModel {
 
       // save byte offset to object
       this.byteOffset = this.embedding.byteOffset;
-
     } catch (error) {
       throw new Error(
         `Error in makeEmbedding for the ${this.modelType} ${this.ioType} ${this.baselineType} model: ${error.message}`
@@ -242,7 +240,7 @@ export class DriftModel {
           this.modelType,
           JSON.stringify(Array.from(this.embedding)),
           this.baselineType,
-          this.embeddingFilePath
+          this.embeddingFilePath,
         ]);
 
         let result = '';
@@ -441,7 +439,6 @@ export class DriftModel {
     try {
       // Skip if training — this method is only for rolling baseline
       if (this.baselineType === 'training') return;
-
       // Calculate vector L2 norm
       const norm = Math.sqrt(
         this.embedding.reduce((sum, val) => sum + val * val, 0)

--- a/tkyo-drift/util/captureSharedScalarMetrics.js
+++ b/tkyo-drift/util/captureSharedScalarMetrics.js
@@ -4,35 +4,29 @@ import path from 'path';
 import { OUTPUT_DIR } from '../tkyoDrift.js';
 
 // Calculates the shared scalar values for a given input/output pair
-export default async function captureSharedScalarMetrics(input, output) {
+export default async function captureSharedScalarMetrics(text, ioType) {
   const timestamp = new Date().toISOString();
 
-  const sharedMetrics = {
-    input: computeMetrics(input),
-    output: computeMetrics(output),
-  };
-
+  const metricSet = computeMetrics(text);
   // Write each metric to its respective file
   await Promise.all(
-    Object.entries(sharedMetrics).flatMap(([ioType, metricSet]) => {
-      return Object.entries(metricSet).map(([metric, value]) => {
-        // Construct the file path
-        const filePath = path.join(
-          OUTPUT_DIR,
-          'scalars',
-          `${ioType}.${metric}.rolling.scalar.jsonl`
-        );
+    Object.entries(metricSet).map(([metric, value]) => {
+      // Construct the file path
+      const filePath = path.join(
+        OUTPUT_DIR,
+        'scalars',
+        `${ioType}.${metric}.rolling.scalar.jsonl`
+      );
 
-        // Ensure the parent directory exists, not the file itself
-        const dirPath = path.dirname(filePath);
-        if (!fs.existsSync(dirPath)) {
-          fs.mkdirSync(dirPath, { recursive: true });
-        }
+      // Ensure the parent directory exists, not the file itself
+      const dirPath = path.dirname(filePath);
+      if (!fs.existsSync(dirPath)) {
+        fs.mkdirSync(dirPath, { recursive: true });
+      }
 
-        const line =
-          JSON.stringify({ timestamp, metrics: { [metric]: value } }) + '\n';
-        return fsPromises.appendFile(filePath, line);
-      });
+      const line =
+        JSON.stringify({ timestamp, metrics: { [metric]: value } }) + '\n';
+      return fsPromises.appendFile(filePath, line);
     })
   );
 }

--- a/tkyo-drift/util/downloadTrainingData.py
+++ b/tkyo-drift/util/downloadTrainingData.py
@@ -3,18 +3,18 @@ import sys
 sys.dont_write_bytecode = True
 from datasets import load_dataset
 
-# data_location = "SmallDoge/SmallThoughts"
+data_location = "SmallDoge/SmallThoughts"
 # data_location = 'open-thoughts/OpenThoughts2-1M'
 # data_location ='gretelai/synthetic_text_to_sql'
 # data_location = 'BatsResearch/bonito-experiment'
-data_location = 'TsukiOwO/open-thoughts_OpenThoughts2-1M'
+# data_location = 'TsukiOwO/open-thoughts_OpenThoughts2-1M'
 
 def dataSetLoader (data_location):
-    # dataset = load_dataset("SmallDoge/SmallThoughts")
+    dataset = load_dataset("SmallDoge/SmallThoughts")
     # dataset = load_dataset("gretelai/synthetic_text_to_sql")
     # dataset = load_dataset("open-thoughts/OpenThoughts2-1M")
     # dataset = load_dataset("BatsResearch/bonito-experiment")
-    dataset = load_dataset("TsukiOwO/open-thoughts_OpenThoughts2-1M")
+    # dataset = load_dataset("TsukiOwO/open-thoughts_OpenThoughts2-1M")
     print(dataset)
     return dataset
 

--- a/tkyo-drift/util/downloadTrainingData.py
+++ b/tkyo-drift/util/downloadTrainingData.py
@@ -3,12 +3,18 @@ import sys
 sys.dont_write_bytecode = True
 from datasets import load_dataset
 
-data_location = "SmallDoge/SmallThoughts"
+# data_location = "SmallDoge/SmallThoughts"
 # data_location = 'open-thoughts/OpenThoughts2-1M'
+# data_location ='gretelai/synthetic_text_to_sql'
+# data_location = 'BatsResearch/bonito-experiment'
+data_location = 'TsukiOwO/open-thoughts_OpenThoughts2-1M'
 
 def dataSetLoader (data_location):
-    dataset = load_dataset("SmallDoge/SmallThoughts")
+    # dataset = load_dataset("SmallDoge/SmallThoughts")
+    # dataset = load_dataset("gretelai/synthetic_text_to_sql")
     # dataset = load_dataset("open-thoughts/OpenThoughts2-1M")
+    # dataset = load_dataset("BatsResearch/bonito-experiment")
+    dataset = load_dataset("TsukiOwO/open-thoughts_OpenThoughts2-1M")
     print(dataset)
     return dataset
 

--- a/tkyo-drift/util/makeLogEntry.js
+++ b/tkyo-drift/util/makeLogEntry.js
@@ -2,7 +2,7 @@ import fs from 'fs';
 import path from 'path';
 import { OUTPUT_DIR } from '../tkyoDrift.js';
 
-export default function makeLogEntry(id, mathObject, type, depth) {
+export default function makeLogEntry(id, mathObject, type) {
   let logPath = '';
   // Construct the destination to the log in the data folder
   if (type === 'COS') {
@@ -14,54 +14,45 @@ export default function makeLogEntry(id, mathObject, type, depth) {
   // Create a timestamp
   const timestamp = new Date().toISOString();
 
-  // Group similarity scores by ioType
-  const grouped = {
-    input: {},
-    output: {},
-  };
+  // Unpack keys from drift metrics: "semantic.problem.rolling"
+  const grouped = {};
 
   // Dynamically unpack all similarity values
   for (const [key, value] of Object.entries(mathObject)) {
+    // Split the key of the math object that got passed on each "." to get the model/ioType and baseline type
     const [modelType, ioType, baselineType] = key.split('.');
-    if (!grouped[ioType][modelType]) {
-      grouped[ioType][modelType] = {};
-    }
+    // Create an object for the IO type within the grouped object
+    if (!grouped[ioType]) grouped[ioType] = {};
+    // Create an object for the model type within the ioType object within the grouped object
+    if (!grouped[ioType][modelType]) grouped[ioType][modelType] = {};
+    // Set the object's object's object's value to the COS similarity or EUC distance that got passed in
     grouped[ioType][modelType][baselineType] = value;
   }
 
-  // Build dynamic headers based on keys present
-  const modelTypes = Object.keys(
-    Object.assign({}, grouped.input, grouped.output)
-  );
+  // Grab the model types from any incoming ioType
+  // const modelTypes = Object.keys(
+  //   Object.values(grouped[0]) || {}
+  // );
+
+  const modelTypes = Object.keys(Object.values(grouped)[0]);
 
   // or dynamically detect if needed
   const baselineTypes = ['rolling', 'training'];
 
-  const headerCols = ['ID', 'DEPTH', 'TIMESTAMP', 'I/O TYPE'];
+  const [[ioType, modelSet]] = Object.entries(grouped);
+
+  const row = [id, timestamp, ioType];
+
+  // Loop through each model in the group
   for (const model of modelTypes) {
+    // loop through each baseline in the group
     for (const baseline of baselineTypes) {
-      headerCols.push(
-        `${model.toUpperCase()} ${baseline.toUpperCase()} ${type}`
-      );
+      const val = modelSet[model]?.[baseline];
+      row.push(val);
     }
   }
-  const headers = headerCols.join(',') + '\n';
 
-  // Helper function to build CSV rows for input/output
-  function buildRow(ioType) {
-    const row = [id, depth, timestamp, ioType];
-    for (const model of modelTypes) {
-      for (const baseline of baselineTypes) {
-        const val = grouped[ioType]?.[model]?.[baseline] ?? '';
-        row.push(val);
-      }
-    }
-    return row.join(',') + '\n';
-  }
-
-  // Build the CSV rows
-  const inputRow = buildRow('input');
-  const outputRow = buildRow('output');
+  const csvLine = row.join(',') + '\n';
 
   // Check if file exists
   const fileExists = fs.existsSync(logPath);
@@ -69,11 +60,25 @@ export default function makeLogEntry(id, mathObject, type, depth) {
   // Write to file
   try {
     if (!fileExists) {
-      fs.writeFileSync(logPath, headers + inputRow + outputRow);
+      // Set the headers that aren't dynamic
+      const headerCols = ['ID', 'TIMESTAMP', 'I/O TYPE'];
+      // For each model in the group
+      for (const model of modelTypes) {
+        // For each baseline in the group
+        for (const baseline of baselineTypes) {
+          // Add the dynamic headers to the array
+          headerCols.push(
+            `${model.toUpperCase()} ${baseline.toUpperCase()} ${type}`
+          );
+        }
+      }
+      // Delimit by comma... this is a CVS after all
+      const headers = headerCols.join(',') + '\n';
+      fs.writeFileSync(logPath, headers + csvLine);
     } else {
-      fs.appendFileSync(logPath, inputRow + outputRow);
+      fs.appendFileSync(logPath, csvLine);
     }
-  } catch(error) {
+  } catch (error) {
     // * Something failed while writing the log
     // ? Could be disk permissions, file lock, etc.
     // ! Consider adding a fallback or alert

--- a/tkyo-drift/util/pythonHNSW.py
+++ b/tkyo-drift/util/pythonHNSW.py
@@ -93,7 +93,7 @@ def HNSW(io_type, model_type, query, baseline_type, file_path):
     # Initialize HNSW index
 
     # 'l2' = Euclidean distance
-    index = hnswlib.Index(space="l2", dim=dims)
+    index = hnswlib.Index(space="cosine", dim=dims)
 
     # Build the index
     # ef_construction : Controls build speed/accuracy trade-off
@@ -102,6 +102,9 @@ def HNSW(io_type, model_type, query, baseline_type, file_path):
 
     # Add data to the index
     index.add_items(data)
+
+    # Set ef for the query
+    index.set_ef(ef_construction)
 
     # Destructuring labels and distances from the nearest neighbors query
     labels, distances = index.knn_query(query, k=k)

--- a/tkyo-drift/util/pythonKMeans.py
+++ b/tkyo-drift/util/pythonKMeans.py
@@ -15,6 +15,8 @@ def kMeansClustering(embeddings):
 
     # Sets num_vectors to the amount of vectors
     num_vectors = len(embeddings)
+    
+
     # Sets dims to the length of the first vector in the array
     dims = len(embeddings[0])
 
@@ -24,6 +26,7 @@ def kMeansClustering(embeddings):
     # Initialize the KMeans clustering algorithm with specific parameters:
     # random_state: Seed for random number generator to ensure reproducibility
     # (Using the same random_state will produce identical results across runs)
+    print(f"Building KMeans for {num_vectors} vectors with {num_of_clusters} clusters.")
     kmeans = KMeans(num_of_clusters, random_state=42069)
 
     # Train the K-means model on our data
@@ -39,6 +42,6 @@ def kMeansClustering(embeddings):
 
     # Ends timing for the entire function
     endTotal = time.perf_counter()
-    print(f"Elapsed: {endTotal - startTotal:.6f} seconds")
+    print(f"KMeans cluster analysis completed in: {endTotal - startTotal:.2f} seconds")
 
     return centroids

--- a/tkyo-drift/util/pythonTrainingEmb.py
+++ b/tkyo-drift/util/pythonTrainingEmb.py
@@ -19,8 +19,6 @@ from datetime import datetime
 import os
 
 
-# TODO: This has a chance of failing during write, but will fail silently.
-# ! We should implement a solution, like writing to a temp file, and then renaming the temp file after completion
 def trainingEmb(model_type, model_name, data_path, io_type, io_type_name):
 
     # Starts the total function timer

--- a/tkyo-drift/util/pythonTrainingEmb.py
+++ b/tkyo-drift/util/pythonTrainingEmb.py
@@ -173,7 +173,6 @@ def trainingEmb(model_type, model_name, data_path, io_type, io_type_name):
         # Compute and log scalar metrics for each item in batch
         # Loop through each embedded vector in the current batch
         for j, vector in enumerate(emb):
-            text = batch[j]  # Get the original text that produced this vector
             timestamp = datetime.utcnow().isoformat() + "Z" 
 
             # ------------- << MODEL-SPECIFIC SCALAR METRICS >> -------------
@@ -229,10 +228,9 @@ def trainingEmb(model_type, model_name, data_path, io_type, io_type_name):
 
     # Create data directories if they doesn't exist
     os.makedirs("data/vectors", exist_ok=True)
-  
 
-    if len(embeddings) < 10000:
-        print(f"You have < 10000 {io_type} embeddings: Saving unfiltered embeddings to data directory.")
+    if len(embeddings) < 1000000:
+        print(f"You have < 1000000 {io_type} embeddings: Saving unfiltered embeddings to data directory.")
         # Assign the number of vectors for the training data
         num_vectors = embeddings.shape[0]
 
@@ -251,7 +249,7 @@ def trainingEmb(model_type, model_name, data_path, io_type, io_type_name):
             # Then write the data
             embeddings.astype(np.float32).tofile(f)
     else:
-        print(f"You have >=  10000 {io_type} embeddings: Performing K Means analysis to filter embeddings.")
+        print(f"You have >=  1000000 {io_type} embeddings: Performing K Means analysis to filter embeddings.")
         kMeansEmbedding = pythonKMeans.kMeansClustering(embeddings)
 
         # Assign the number of vectors for the training data

--- a/tkyo-drift/util/writeSharedScalars.py
+++ b/tkyo-drift/util/writeSharedScalars.py
@@ -2,6 +2,7 @@ from datasets import Dataset, concatenate_datasets
 import os
 import json
 import numpy as np
+import time
 from datetime import datetime
 from util.pythonTrainingEmb import resolve_io_column
 
@@ -21,6 +22,9 @@ def write_shared_scalar_metrics(data_path, io_type, io_type_name):
 
     # Use our helper to extract the proper column of input/output text
     batch_texts = resolve_io_column(dataset, io_type_name)
+    
+    # start timer:
+    start_time = time.perf_counter()
 
     # Loop through every text item and compute shared scalar values
     for i, text in enumerate(batch_texts):
@@ -80,3 +84,27 @@ def write_shared_scalar_metrics(data_path, io_type, io_type_name):
                     "timestamp": timestamp,
                     "metrics": {metric: value}
                 }) + "\n")
+
+        # Print progress every 100 batches
+        if i % 100 == 0:
+            elapsed = time.perf_counter() - start_time
+            processed = min(i + 100, len(batch_texts))
+            remaining = len(batch_texts) - processed
+            est_total = (elapsed / processed) * len(batch_texts) if processed else 0
+            est_remaining = est_total - elapsed
+            mins, secs = divmod(est_remaining, 60)
+            
+        if est_remaining < 60:
+            eta_display = f"{int(secs)}s"
+        else:
+            eta_display = f"{int(mins):02d}:{int(secs):02d}"
+
+        print(
+            f"Processed {processed}/{len(batch_texts)} | ETA: {eta_display} ",
+            end="\r",
+            flush=True
+        )
+
+
+
+    print()

--- a/tkyo-drift/util/writeSharedScalars.py
+++ b/tkyo-drift/util/writeSharedScalars.py
@@ -23,7 +23,12 @@ def write_shared_scalar_metrics(data_path, io_type, io_type_name):
     batch_texts = resolve_io_column(dataset, io_type_name)
 
     # Loop through every text item and compute shared scalar values
-    for text in batch_texts:
+    for i, text in enumerate(batch_texts):
+
+        if not isinstance(text, str) or not text.strip():
+            print(f"[WARN] Skipping index {i}: Text is empty or not a string.")   
+            continue     
+
         timestamp = datetime.now().isoformat()  # ISO timestamp for tracking
 
         # --- Compute Shared Metrics ---


### PR DESCRIPTION
Revamp of the batch and one off ingestion to allow for a break from the I/O pair schema. The system now successfully allows you to embed individual inputs.

All manual tests pass, including batch embedding, on off embedding, cli print out, and scalar print outs.

Added addition print lines to the batch embedding process for clarity.

Added a metric shit ton of stuff  to the readme.

Found, triaged, and then resolved a bug with ASYNC await calls in the tkyo drift main logic.
Found triaged and then resolved an issue with the python embedding process and js embedding process no using the same normalization levels, and how they parse large token texts in the same 

We still need to update general comment lines throughout the program as references to "i/o pairs" still exist.

There is still an issue with KMEAN/HNSW recall of an input embedding that SHOULD exist in the training data. Most metrics show NO drift (as they should) while PROBLEM SEMANTIC TRAINING and PROBLEM LEXICAL TRAINING comparisons show WILD drift (they shouldn't).